### PR TITLE
Minikube nextcloud

### DIFF
--- a/charts/all/Chart.yaml
+++ b/charts/all/Chart.yaml
@@ -104,3 +104,7 @@ dependencies:
     condition: feature.redis
     tags:
       - storage
+  - name: nextcloud
+    version: ^3.5.2
+    repository: https://nextcloud.github.io/helm/
+    condition: feature.nextcloud

--- a/charts/all/values.yaml
+++ b/charts/all/values.yaml
@@ -32,6 +32,7 @@ namespace:
 feature:
   jaeger: false
   redis: true
+  nextcloud: false
 layer0-web:
   enabled: true
   environment:

--- a/charts/layer1_port_owncloud/templates/configmap.yaml
+++ b/charts/layer1_port_owncloud/templates/configmap.yaml
@@ -22,4 +22,11 @@ data:
   OWNCLOUD_INSTALLATION_URL: {{ .ADDRESS | quote }}
   OWNCLOUD_OAUTH_CLIENT_SECRET: {{ .OAUTH_CLIENT_SECRET | quote }}
   SERVICENAME: {{ .name | replace "." "-" | replace ":" "-" }}
+  {{ if not .INTERNAL_ADDRESS }}
+  OWNCLOUD_INTERNAL_INSTALLATION_URL: {{ .ADDRESS | quote }}
+  {{ end }}
+  {{ if .INTERNAL_ADDRESS }}
+  OWNCLOUD_INTERNAL_INSTALLATION_URL: {{ .INTERNAL_ADDRESS | quote }}
+  {{ end }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
This patch's aim is to make it possible to run a fully local k8s environment using minikube with RDS embedded in an EFSS running in the same local k8s environment.

On one hand, it add a helm char for NextCloud to the `all` chart, disabled by default.

On the other, it adds the possibility of configuring NexCloud (or OwnCloud, or any other EFSS) with both an internal address, to access it from within the k8s environment, and an external address, to access it from the browser.